### PR TITLE
Add option to toggle leaderboard display

### DIFF
--- a/judge/forms.py
+++ b/judge/forms.py
@@ -82,6 +82,10 @@ class NewContestForm(forms.Form):
     is_public = forms.BooleanField(label='Is this contest public?', required=False)
     """Contest is_public property"""
 
+    enable_leaderboard = forms.BooleanField(label='Enable leaderboard', required=False,
+                                             initial=True)
+    """Contest enable_leaderboard property"""
+
     enable_linter_score = forms.BooleanField(label='Enable linter scoring',
                                              required=False)
     """Contest enable_linter_score property"""
@@ -111,23 +115,28 @@ class UpdateContestForm(forms.Form):
     Form to update the timeline of the Contest
     """
 
-    contest_start = forms.DateTimeField(label='Start Date',
+    contest_start = forms.DateTimeField(label='Start Date', required=False,
                                         widget=forms.DateTimeInput(attrs={'class': 'form-control'}),
                                         help_text='Specify when the contest begins.')
     """Contest Start Timestamp"""
 
-    contest_soft_end = forms.DateTimeField(label='Soft End Date',
+    contest_soft_end = forms.DateTimeField(label='Soft End Date', required=False,
                                            widget=forms.DateTimeInput(
                                                attrs={'class': 'form-control'}),
                                            help_text='Specify after when would you like to \
                                                       penalize submissions.')
     """Contest Soft End Timestamp"""
 
-    contest_hard_end = forms.DateTimeField(label='Hard End Date',
+    contest_hard_end = forms.DateTimeField(label='Hard End Date', required=False,
                                            widget=forms.DateTimeInput(
                                                attrs={'class': 'form-control'}),
                                            help_text='Specify when the contest completely ends.')
     """Contest Hard End Timestamp"""
+
+    show_leaderboard = forms.BooleanField(label='Display leaderboard', required=False,
+                                            help_text='Specify whether leaderboard should be \
+                                                        displayed or not.')
+    """Contest enable_leaderboard property"""
 
     def clean(self):
         cleaned_data = super().clean()

--- a/judge/handler.py
+++ b/judge/handler.py
@@ -26,6 +26,7 @@ def _check_and_remove(*fullpaths):
 
 def process_contest(contest_name: str, contest_start: datetime, contest_soft_end: datetime,
                     contest_hard_end: datetime, penalty: float, is_public: bool,
+                    enable_leaderboard: bool,
                     enable_linter_score: bool,
                     enable_poster_score: bool) -> Tuple[bool, Union[ValidationError, str]]:
     """
@@ -37,6 +38,7 @@ def process_contest(contest_name: str, contest_start: datetime, contest_soft_end
     :param contest_hard_end: A `datetime` object representing the hard deadline of the contest
     :param penalty: A penalty score for late submissions
     :param is_public: Field to indicate if the contest is public (or private)
+    :param enable_leaderboard: Field to indicate if leaderboard is to be maintained
     :param enable_linter_score: Field to indicate if linter scoring is enabled in the contest
     :param enable_poster_score: Field to indicate if poster scoring is enabled in the contest
     :returns: A 2-tuple - 1st element indicating whether the processing has succeeded, and
@@ -53,6 +55,7 @@ def process_contest(contest_name: str, contest_start: datetime, contest_soft_end
                                                     soft_end_datetime=contest_soft_end,
                                                     hard_end_datetime=contest_hard_end,
                                                     penalty=penalty, public=is_public,
+                                                    enable_leaderboard=enable_leaderboard,
                                                     enable_linter_score=enable_linter_score,
                                                     enable_poster_score=enable_poster_score)
     # Catch any weird errors that might pop up during the creation
@@ -502,7 +505,7 @@ def update_poster_score(submission_id: str, new_score: int):
     except Exception as other_err:
         return (False, ValidationError(str(other_err)))
 
-    if old_highscore != ppf.score:
+    if old_highscore != ppf.score and submission.problem.contest.enable_leaderboard:
         # Update the leaderboard only if submission improved the final score
         update_leaderboard(submission.problem.contest.pk,
                            submission.participant.email)

--- a/judge/models.py
+++ b/judge/models.py
@@ -61,6 +61,12 @@ class Contest(models.Model):
     public = models.BooleanField(default=False)
     """Is the contest public?"""
 
+    enable_leaderboard = models.BooleanField(default=True)
+    """Enable leaderboard"""
+
+    show_leaderboard = models.BooleanField(default=False)
+    """Display leaderboard"""
+
     enable_linter_score = models.BooleanField(default=True)
     """Enable linter scoring"""
 

--- a/judge/templates/judge/contest_detail.html
+++ b/judge/templates/judge/contest_detail.html
@@ -39,6 +39,9 @@
             {% if type == 'Poster' %}
             {% if curr_time < contest.hard_end_datetime %}<a class="btn btn-primary my-1 btn-sm"
                 href="{% url 'judge:new_problem' contest.pk %}">Add Problem</a>{% endif %}
+            {% if curr_time < contest.hard_end_datetime or contest.enable_leaderboard %}
+            <button type="button" class="btn btn-primary my-1 btn-sm" data-toggle="modal"
+                data-target="#modal-update-dates">Update contest</button>{% endif %}
             <a class="btn btn-primary my-1 btn-sm" href="{% url 'judge:contest_scores_csv' contest.pk %}">Download
                 Scores</a>
             {% endif %}
@@ -46,12 +49,10 @@
             {% if not contest.public %}<a class="btn btn-primary my-1 btn-sm"
                 href="{% url 'judge:get_participants' contest.pk %}">See
                 participants</a>{% endif %}
-            {% if type == 'Poster' and curr_time < contest.hard_end_datetime %}<button type="button"
-                class="btn btn-primary my-1 btn-sm" data-toggle="modal" data-target="#modal-update-dates">Update
-                dates</button>{% endif %}
         </div>
     </div>
-    {% if type == 'Poster' and curr_time < contest.hard_end_datetime %}
+    {% if curr_time < contest.hard_end_datetime or contest.enable_leaderboard %}
+    {% if type == 'Poster' %}
     <div class="modal fade" id="modal-update-dates" tabindex="-1" role="dialog" aria-hidden="true">
         <div class="modal-dialog modal- modal-dialog-centered modal-sm" role="document">
             <div class="modal-content">
@@ -70,6 +71,8 @@
                                 {% csrf_token %}
                                 {% for field in form %}
                                 <div class="form-group mb-1">
+                                    {% if field.value != 1 and field.value != 0 %}
+                                    {% if curr_time < contest.hard_end_datetime %}
                                     {{ field.label_tag }}
                                     <div class="input-group input-group-alternative">
                                         <div class="input-group-prepend">
@@ -85,6 +88,19 @@
                                         {{ field.errors|striptags }}
                                     </div>
                                     {% endif %}
+                                    {% endif %}
+                                    {% elif contest.enable_leaderboard %}
+                                    {{ field.label_tag }}
+                                    {{ field }}
+                                    {% if field.help_text %}
+                                    <small class="form-text text-muted">{{ field.help_text|safe }}</small>
+                                    {% endif %}
+                                    {% if field.errors %}
+                                    <div class="alert alert-danger mt-2" role="alert">
+                                        {{ field.errors|striptags }}
+                                    </div>
+                                    {% endif %}
+                                    {% endif %}
                                 </div>
                                 {% endfor %}
                                 <div class="text-center">
@@ -97,6 +113,7 @@
             </div>
         </div>
     </div>
+    {% endif %}
     {% endif %}
     <div class="col-md-5 float-right">
         <i class="ni ni-calendar-grid-58"></i> Starts at {{ contest.start_datetime|localtime }}<br>
@@ -125,6 +142,8 @@
         </div>
         {% endfor %}
     </div>
+    {% if contest.enable_leaderboard %}
+    {% if type == 'Poster' or contest.show_leaderboard %}
     <div class="col-12 col-md-5 my-4">
         {% if leaderboard_status %}
         <table class="table table-striped">
@@ -149,6 +168,8 @@
         <p>{{ leaderboard }}</p>
         {% endif %}
     </div>
+    {% endif %}
+    {% endif %}
     {% if type == 'Poster' %}
     <div class="col-12 my-4">
         <form action="{% url 'judge:delete_contest' contest.pk %}" method="POST">


### PR DESCRIPTION
Adds option to enable leaderboard in contest create form. If disabled, leaderboard is not maintained and cannot be enabled later on.
Adds option to display leaderboard to participants in update contest form. Only available if leaderboard is enabled at contest creation time. Display leaderboard option is always available after contest creation if leaderboard was enabled.
Potential bug: Update contest form error on first reload after hard deadline has passed.
