### PR TITLE
Use 24h format for input and display time

### DIFF
--- a/autojudge/settings.py
+++ b/autojudge/settings.py
@@ -111,9 +111,14 @@ TIME_ZONE = 'Asia/Kolkata'
 
 USE_I18N = True
 
-USE_L10N = True
+# Disabled localization
+# Use l10n template library if needed
+# https://docs.djangoproject.com/en/3.2/topics/i18n/formatting/#controlling-localization-in-templates
+# USE_L10N = True
 
 USE_TZ = True
+
+DATETIME_FORMAT = "d M Y, H:i:s"
 
 
 # Static files (CSS, JavaScript, Images)

--- a/judge/templates/judge/contest_detail.html
+++ b/judge/templates/judge/contest_detail.html
@@ -8,20 +8,24 @@
 <li class="breadcrumb-item active" aria-current="page">Contest {{ contest.pk }}</li>
 {% endblock %}
 
+{% block styles %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
+{% endblock %}
+
 {% block scripts %}
-<!-- TODO Fix this -->
-<!-- <script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
+<script src="https://cdn.jsdelivr.net/npm/flatpickr"></script>
 <script>
     var date_options = {
         enableTime: true,
         dateFormat: "Y-m-d H:i:S",
+        time_24hr: true,
         allowInput: true,
         enableSeconds: true,
     }
     $("#id_contest_start").flatpickr(date_options)
     $("#id_contest_soft_end").flatpickr(date_options)
     $("#id_contest_hard_end").flatpickr(date_options)
-</script> -->
+</script>
 {% if form.errors %}
 <script>
     $(window).on('load', function () {

--- a/judge/templates/judge/new_contest.html
+++ b/judge/templates/judge/new_contest.html
@@ -12,6 +12,7 @@
     var date_options = {
         enableTime: true,
         dateFormat: "Y-m-d H:i:S",
+        time_24hr: true,
         allowInput: true,
         enableSeconds: true
     }


### PR DESCRIPTION
Use 24h format for flatpickr and datetime display.
Disabled localization.
Can't manually type time in flatpickr in update contest form.