### PR TITLE
Adding fix for Memory Limit

### DIFF
--- a/judge/forms.py
+++ b/judge/forms.py
@@ -235,7 +235,7 @@ class NewProblemForm(forms.Form):
                                       widget=forms.NumberInput(attrs={'class': 'form-control'}),
                                       initial=0, min_value=0,
                                       help_text='Specify a memory limit in MB for the execution \
-                                                 of the program.')
+                                                 of the program.If not specified(set to 0) memory limit will default to 1 MB')
     """Problem Memory limit"""
 
     file_exts = forms.CharField(label='Permitted File extensions for submissions',

--- a/judge/handler.py
+++ b/judge/handler.py
@@ -190,6 +190,11 @@ def process_problem(contest_id: int,
         # This will happen when both compilation_script and test_script were None
         os.makedirs(os.path.join('content', 'problems', new_problem.code))
 
+    #checking incase memory limit was set to 0 accidentally
+    if new_problem.memory_limit==0:
+        new_problem.memory_limit=1 #Defaulting it to 1 MB
+
+    
     if no_comp_script:
         # Copy the default comp_script if the user did not upload custom
         copyfile(os.path.join('judge', 'default', 'compilation_script.sh'),


### PR DESCRIPTION
Defaults the memory limit to 1 MB if the memory limit is set to 0 in the add problem page 