### PR TITLE
Fix update contest flatpickr time input

### DIFF
--- a/judge/templates/judge/contest_detail.html
+++ b/judge/templates/judge/contest_detail.html
@@ -19,8 +19,10 @@
         enableTime: true,
         dateFormat: "Y-m-d H:i:S",
         time_24hr: true,
+        defaultHour: 0,
         allowInput: true,
         enableSeconds: true,
+        static: true,
     }
     $("#id_contest_start").flatpickr(date_options)
     $("#id_contest_soft_end").flatpickr(date_options)

--- a/judge/templates/judge/new_contest.html
+++ b/judge/templates/judge/new_contest.html
@@ -13,6 +13,7 @@
         enableTime: true,
         dateFormat: "Y-m-d H:i:S",
         time_24hr: true,
+        defaultHour: 0,
         allowInput: true,
         enableSeconds: true
     }


### PR DESCRIPTION
Set static to true for flatpickr in update contest modal.
Also set default hour to 00 instead of 12 in flatpickr.