### PR TITLE
Allow Admins to change 'Contest' string

### DIFF
--- a/autojudge/settings.py
+++ b/autojudge/settings.py
@@ -64,6 +64,8 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
                 'social_django.context_processors.backends',
                 'social_django.context_processors.login_redirect',
+                'judge.context_processors.index_string',
+                'judge.context_processors.index_string_plural',
             ],
         },
     },

--- a/judge/context_processors.py
+++ b/judge/context_processors.py
@@ -1,0 +1,8 @@
+from .models import IndexString
+
+# Custom context processors
+def index_string(request):
+    return {'index_string': IndexString.objects.get(pk=1).index_str}
+
+def index_string_plural(request):
+    return {'index_string_plural': IndexString.objects.get(pk=1).index_str_plural}

--- a/judge/fixtures/index_string.json
+++ b/judge/fixtures/index_string.json
@@ -1,0 +1,10 @@
+[
+    {
+      "model": "judge.IndexString",
+      "pk": 1,
+      "fields": {
+        "index_str": "Contest",
+        "index_str_plural": "Contests"
+      }
+    }
+]

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -46,6 +46,23 @@ class MultiEmailField(forms.Field):
         return value
 
 
+class IndexStringForm(forms.Form):
+    """
+    Form for editing index string
+    """
+    index_str = forms.CharField(label='Index String', min_length=1, max_length=25,
+                                   strip=True,
+                                   widget=forms.TextInput(attrs={'class': 'form-control'}),
+                                   help_text='Enter string to replace \'Contest\' string.')
+    """Index String"""
+
+    index_str_plural = forms.CharField(label='Plural Index String', min_length=1,
+                                   max_length=25, strip=True,
+                                   widget=forms.TextInput(attrs={'class': 'form-control'}),
+                                   help_text='Enter plural form of above string \
+                                             (to replace \'Contests\' string).')
+    """Plural Index String"""
+
 class NewContestForm(forms.Form):
     """
     Form for creating a new Contest.

--- a/judge/handler.py
+++ b/judge/handler.py
@@ -23,6 +23,26 @@ def _check_and_remove(*fullpaths):
         if os.path.exists(fullpath):
             os.remove(fullpath)
 
+def update_index_string(index_str: str, index_str_plural: str) -> Tuple[bool, ValidationError]:
+    """
+    Function to update :class:`~judge.models.IndexString`.
+    """
+    indexString = models.IndexString.objects.filter(pk=1)
+    if not indexString.exists():
+        return (False, ValidationError('IndexString object not found'))
+    indexString = indexString[0]
+
+    indexString.index_str = index_str
+    indexString.index_str_plural = index_str_plural
+    try:
+        indexString.save()
+    # Catch any weird errors that might pop up during the modification
+    except Exception as other_err:
+        print_exc()
+        return (False, ValidationError(str(other_err)))
+    else:
+        return (True, None)
+
 
 def process_contest(contest_name: str, contest_start: datetime, contest_soft_end: datetime,
                     contest_hard_end: datetime, penalty: float, submission_limit: int,

--- a/judge/models.py
+++ b/judge/models.py
@@ -37,6 +37,18 @@ def comment_upload_location(instance, filename):
     return 'content/comment/{}.yml'.format(instance.id)
 
 
+class IndexString(models.Model):
+    """
+    Model for global string ('Contests' string on index) 
+    """
+
+    index_str = models.CharField(max_length=25, default='Contest')
+    """'Contest' string on index page"""
+
+    index_str_plural = models.CharField(max_length=25, default='Contests')
+    """'Contests' string on index page"""
+
+
 class Contest(models.Model):
     """
     Model for Contest.

--- a/judge/templates/judge/contest_detail.html
+++ b/judge/templates/judge/contest_detail.html
@@ -5,7 +5,7 @@
 {% block title %}{{ contest.name }}{% endblock %}
 
 {% block breadcrumb %}
-<li class="breadcrumb-item active" aria-current="page">Contest {{ contest.pk }}</li>
+<li class="breadcrumb-item active" aria-current="page">{{ index_string }} {{ contest.pk }}</li>
 {% endblock %}
 
 {% block styles %}
@@ -44,7 +44,7 @@
             {% if curr_time < contest.hard_end_datetime %}<a class="btn btn-primary my-1 btn-sm"
                 href="{% url 'judge:new_problem' contest.pk %}">Add Problem</a>{% endif %}
             <button type="button" class="btn btn-primary my-1 btn-sm" data-toggle="modal"
-                data-target="#modal-update-dates">Update contest</button>
+                data-target="#modal-update-dates">Update {{ index_string }}</button>
             <a class="btn btn-primary my-1 btn-sm" href="{% url 'judge:contest_scores_csv' contest.pk %}">Download
                 Scores</a>
             {% endif %}
@@ -61,7 +61,7 @@
                 <div class="modal-body p-0">
                     <div class="card bg-secondary shadow border-0">
                         <div class="card-body px-lg-5 py-lg-5">
-                            <div class="text-center text-muted mb-4">UPDATE CONTEST</div>
+                            <div class="text-center text-muted mb-4">Update {{ index_string }}</div>
                             <form method="POST" role="form">
                                 {% if form.non_field_errors %}
                                 {% for nfe in form.non_field_errors %}
@@ -177,7 +177,7 @@
             {% csrf_token %}
             <button type="submit" class="btn btn-danger btn-icon">
                 <span class="btn-inner--icon"><i class="fas fa-trash pb-2"></i></span>
-                <span class="btn-inner--text">Delete Contest</span>
+                <span class="btn-inner--text">Delete {{ index_string }}</span>
             </button>
         </form>
     </div>

--- a/judge/templates/judge/contest_persons.html
+++ b/judge/templates/judge/contest_persons.html
@@ -1,9 +1,9 @@
 {% extends 'judge/base.html' %}
 
-{% block title %}{{ type }}s | Contest {{ contest_id }}{% endblock %}
+{% block title %}{{ type }}s | {{ index_string }} {{ contest_id }}{% endblock %}
 
 {% block breadcrumb %}
-<li class="breadcrumb-item"><a href="{% url 'judge:contest_detail' contest_id %}">Contest {{ contest_id }}</a></li>
+<li class="breadcrumb-item"><a href="{% url 'judge:contest_detail' contest_id %}">{{ index_string }} {{ contest_id }}</a></li>
 <li class="breadcrumb-item active" aria-current="page">{{ type }}s</li>
 {% endblock %}
 
@@ -50,7 +50,7 @@
                 {% endif %}
             </div>
             {% empty %}
-            <p>There are no {{ type|lower }}s for this contest.</p>
+            <p>There are no {{ type|lower }}s for this {{ index_string }}.</p>
             {% endfor %}
         </div>
     </div>

--- a/judge/templates/judge/edit_index_string.html
+++ b/judge/templates/judge/edit_index_string.html
@@ -1,22 +1,15 @@
 {% extends 'judge/base.html' %}
 
-{% block title %}Add {{ type }} | {{ index_string }} {{ contest_id }}{% endblock %}
+{% block title %}Edit Index String{% endblock %}
 
 {% block breadcrumb %}
-<li class="breadcrumb-item"><a href="{% url 'judge:contest_detail' contest_id %}">{{ index_string }} {{ contest_id }}</a></li>
-{% if type == 'Poster' %}
-<li class="breadcrumb-item"><a href="{% url 'judge:get_posters' contest_id %}">Posters</a></li>
-{% endif %}
-{% if type == 'Participant' %}
-<li class="breadcrumb-item"><a href="{% url 'judge:get_participants' contest_id %}">Participants</a></li>
-{% endif %}
-<li class="breadcrumb-item active" aria-current="page">Add {{ type }}</li>
+<li class="breadcrumb-item active" aria-current="page">Edit Index String</li>
 {% endblock %}
 
 {% block content %}
 <div class="row">
     <div class="col-12">
-        <h2>Add {{ type }}</h2>
+        <h2>Edit Index String</h2>
     </div>
     <div class="col-12">
         <form method="POST">
@@ -43,7 +36,7 @@
                 {% endif %}
             </div>
             {% endfor %}
-            <button type="submit" class="btn btn-primary">Add {{ type }}</button>
+            <button type="submit" class="btn btn-primary">Update</button>
         </form>
     </div>
 </div>

--- a/judge/templates/judge/edit_problem.html
+++ b/judge/templates/judge/edit_problem.html
@@ -1,9 +1,9 @@
 {% extends "judge/base.html" %}
 
-{% block title %}Edit Problem {{ problem.code }} | Contest {{ contest.pk }}{% endblock %}
+{% block title %}Edit Problem {{ problem.code }} | {{ index_string }} {{ contest.pk }}{% endblock %}
 
 {% block breadcrumb %}
-<li class="breadcrumb-item"><a href="{% url 'judge:contest_detail' contest.pk %}">Contest {{ contest.pk }}</a></li>
+<li class="breadcrumb-item"><a href="{% url 'judge:contest_detail' contest.pk %}">{{ index_string }} {{ contest.pk }}</a></li>
 <li class="breadcrumb-item"><a href="{% url 'judge:problem_detail' problem.code %}">Problem {{ problem.code }}</a></li>
 <li class="breadcrumb-item active" aria-current="page">Edit</li>
 {% endblock %}

--- a/judge/templates/judge/index.html
+++ b/judge/templates/judge/index.html
@@ -3,12 +3,17 @@
 {% block content %}
 <div class="row">
     <div class="col-12">
-        <h1 class="d-inline-block">Contests</h1>
+        <h1 class="d-inline-block">{{ index_string_plural }}</h1>
         {% if user.is_authenticated and user_rank == 2 %}
         <a class="btn btn-icon btn-primary float-right" href="{% url 'judge:new_contest' %}">
             <span class="btn-inner--icon"><i class="fas fa-plus"></i></span>
-            <span class="btn-inner--text">New Contest</span>
+            <span class="btn-inner--text">New {{ index_string }}</span>
         </a>
+        <div class="float-left">
+            <a href="{% url 'judge:edit_index_string' %}" class="btn btn-primary">
+                <i class="fas fa-edit"></i>
+            </a>
+        </div>
         {% endif %}
     </div>
     <div class="col-12">
@@ -26,13 +31,13 @@
                         {% else %}<span class="badge badge-warning">Participant</span>{% endif %}
                     </div>
                 </div>
-                <a href="{% url 'judge:contest_detail' contest.pk %}" class="card-link">Go to contest page</a>
+                <a href="{% url 'judge:contest_detail' contest.pk %}" class="card-link">Go to {{ index_string }} page</a>
             </div>
         </div>
         {% endif %}
         {% empty %}
         <div class="col-12">
-            No active contests for the time being. Create a new contest or check later.
+            No active {{ index_string_plural }} for the time being.
         </div>
         {% endfor %}
     </div>

--- a/judge/templates/judge/new_contest.html
+++ b/judge/templates/judge/new_contest.html
@@ -1,6 +1,6 @@
 {% extends "judge/base.html" %}
 
-{% block title %}New Contest{% endblock %}
+{% block title %}New {{ index_string }}{% endblock %}
 
 {% block styles %}
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/flatpickr/dist/flatpickr.min.css">
@@ -23,13 +23,13 @@
 {% endblock %}
 
 {% block breadcrumb %}
-<li class="breadcrumb-item active" aria-current="page">New Contest</li>
+<li class="breadcrumb-item active" aria-current="page">New {{ index_string }}</li>
 {% endblock %}
 
 {% block content %}
 <div class="row my-2">
     <div class="col-12">
-        <h2>New Contest</h2>
+        <h2>New {{ index_string }}</h2>
     </div>
 </div>
 <div class="row">

--- a/judge/templates/judge/new_problem.html
+++ b/judge/templates/judge/new_problem.html
@@ -1,9 +1,9 @@
 {% extends "judge/base.html" %}
 
-{% block title %}New Problem | Contest {{ contest.pk }}{% endblock %}
+{% block title %}New Problem | {{ index_string }} {{ contest.pk }}{% endblock %}
 
 {% block breadcrumb %}
-<li class="breadcrumb-item"><a href="{% url 'judge:contest_detail' contest.pk %}">Contest {{ contest.pk }}</a></li>
+<li class="breadcrumb-item"><a href="{% url 'judge:contest_detail' contest.pk %}">{{ index_string }} {{ contest.pk }}</a></li>
 <li class="breadcrumb-item active" aria-current="page">New Problem</li>
 {% endblock %}
 

--- a/judge/templates/judge/problem_detail.html
+++ b/judge/templates/judge/problem_detail.html
@@ -1,9 +1,9 @@
 {% extends 'judge/base.html' %}
 
-{% block title %}Problem {{ problem.code }} | Contest {{ problem.contest }}{% endblock %}
+{% block title %}Problem {{ problem.code }} | {{ index_string }} {{ problem.contest }}{% endblock %}
 
 {% block breadcrumb %}
-<li class="breadcrumb-item"><a href="{% url 'judge:contest_detail' problem.contest.pk %}">Contest
+<li class="breadcrumb-item"><a href="{% url 'judge:contest_detail' problem.contest.pk %}">{{ index_string }}
         {{ problem.contest.pk }}</a></li>
 <li class="breadcrumb-item active" aria-current="page">Problem {{ problem.code }}</li>
 {% endblock %}

--- a/judge/templates/judge/problem_submissions.html
+++ b/judge/templates/judge/problem_submissions.html
@@ -1,9 +1,9 @@
 {% extends 'judge/base.html' %}
 
-{% block title %} Submissions | Problem {{ problem.code }} | Contest {{ problem.contest }}{% endblock %}
+{% block title %} Submissions | Problem {{ problem.code }} | {{ index_string }} {{ problem.contest }}{% endblock %}
 
 {% block breadcrumb %}
-<li class="breadcrumb-item"><a href="{% url 'judge:contest_detail' problem.contest.pk %}">Contest
+<li class="breadcrumb-item"><a href="{% url 'judge:contest_detail' problem.contest.pk %}">{{ index_string }}
         {{ problem.contest.pk }}</a></li>
 <li class="breadcrumb-item"><a href="{% url 'judge:problem_detail' problem.pk %}">Problem {{ problem.code }}</a></li>
 <li class="breadcrumb-item active" aria-current="page">Submissions</li>

--- a/judge/templates/judge/submission_detail.html
+++ b/judge/templates/judge/submission_detail.html
@@ -1,9 +1,9 @@
 {% extends 'judge/base.html' %}
 
-{% block title %}Submission | Problem {{ problem.code }} | Contest {{ problem.contest }}{% endblock %}
+{% block title %}Submission | Problem {{ problem.code }} | {{ index_string }} {{ problem.contest }}{% endblock %}
 
 {% block breadcrumb %}
-<li class="breadcrumb-item"><a href="{% url 'judge:contest_detail' problem.contest.pk %}">Contest
+<li class="breadcrumb-item"><a href="{% url 'judge:contest_detail' problem.contest.pk %}">{{ index_string }}
         {{ problem.contest.pk }}</a></li>
 <li class="breadcrumb-item"><a href="{% url 'judge:problem_detail' problem.pk %}">Problem {{ problem.code }}</a></li>
 <li class="breadcrumb-item"><a href="{% url 'judge:problem_submissions' problem.pk %}">Submissions</a></li>

--- a/judge/urls.py
+++ b/judge/urls.py
@@ -12,6 +12,7 @@ handler500 = views.handler500
 urlpatterns = [
     # General-purpose paths
     path('', views.index, name='index'),
+    path('edit-index-string', views.edit_index_string, name='edit_index_string'),
     path('login/', LoginView.as_view(), name='login'),
     path('logout/', LogoutView.as_view(), name='logout'),
     path('auth/', include('social_django.urls', namespace='social')),

--- a/judge/views.py
+++ b/judge/views.py
@@ -11,6 +11,7 @@ from django.shortcuts import render, redirect, get_object_or_404
 
 from . import handler
 from .models import Contest, Problem, TestCase, Submission
+from .forms import IndexStringForm
 from .forms import NewContestForm, AddPersonToContestForm, DeletePersonFromContestForm
 from .forms import NewProblemForm, EditProblemForm, NewSubmissionForm, AddTestCaseForm
 from .forms import NewCommentForm, UpdateContestForm, AddPosterScoreForm
@@ -85,6 +86,31 @@ def index(request):
     context['user_rank'] = 0 if user is None else user_rank
     return render(request, 'judge/index.html', context)
 
+def edit_index_string(request):
+    """
+    Renders view for the page to edit index string.
+
+    :param request: the request object used
+    :type request: HttpRequest
+    """
+    user = _get_user(request)
+    if user is None:
+        return handler404(request)
+    status, rank_or_error = handler.get_person_rank(user.email)
+    if not status or rank_or_error != 2:
+        return handler404(request)
+    if request.method == 'POST':
+        form = IndexStringForm(request.POST)
+        if form.is_valid():
+            status, maybe_error = handler.update_index_string(**form.cleaned_data)
+            if status:
+                return redirect(reverse('judge:index'))
+            else:
+                form.add_error(None, maybe_error)
+    else:
+        form = IndexStringForm()
+    context = {'form': form}
+    return render(request, 'judge/edit_index_string.html', context)
 
 def new_contest(request):
     """


### PR DESCRIPTION
Provides an edit button next to Contest string on index page for admins
Allows admin to update the string with new 'Contest'/'Contests' string for all occurrences on the site 
Need to run `python manage.py loaddata index_string` on first setup