### PR TITLE
Update contest form flatpickr minute increment fix

### DIFF
--- a/judge/templates/judge/contest_detail.html
+++ b/judge/templates/judge/contest_detail.html
@@ -21,6 +21,7 @@
         time_24hr: true,
         defaultHour: 0,
         allowInput: true,
+        minuteIncrement: 1,
         enableSeconds: true,
         static: true,
     }


### PR DESCRIPTION
Set flatpickr minute increment to 1 instead of 5 for update contest form. Update contest form now updates contest times for input minute values not multiple of 5