### PR TITLE
Adding fix for timeout issue and file checks for proper C file

### DIFF
--- a/content/compile_and_test.py
+++ b/content/compile_and_test.py
@@ -16,10 +16,18 @@ parser.add_argument('--submission_config', type=str,
                             ...""")
 args = parser.parse_args()
 
+def is_binary(fileName):
+    try:
+        with open(fileName) as check_file:  # try open file in text mode
+            check_file.read()
+            return False
+    except:  # if fail then file is non-text (binary)
+        return True
+
 with open(args.submission_config) as f:
     sub_info = [x[:-1] for x in f.readlines()]
 
-#print(sub_info)
+print(sub_info)
 
 # Retain the first 2 lines alone
 subprocess.call(['rm', args.submission_config])
@@ -29,14 +37,23 @@ with open(args.submission_config, "w") as stat_file:
 
 # Run clangjudge only for c/c++ submissions
 if (sub_info[2]==".c" or sub_info[2]==".cpp") and sub_info[3]:
-    try:
-        subprocess.check_output(['./judgeClangTool/clangjudge', sub_info[3],
+   
+    isFileBinary=is_binary('submissions/submission_{}{}'.format(sub_info[1], sub_info[2]))
+    #print(isFileBinary)
+
+    if(isFileBinary):
+        #print("binary found!")
+        pass
+    
+    else:
+        try:
+            subprocess.check_output(['./judgeClangTool/clangjudge', sub_info[3],
                                 'submissions/submission_{}{}'.format(sub_info[1], sub_info[2])])
-    except subprocess.CalledProcessError as e:
-        error_msg = str(e.output.decode('utf-8'))
-        clangtool_log_file = 'sub_clangjudge_{}.log'.format(sub_info[1])
-        with open('tmp/' + clangtool_log_file, "w") as log_file:
-            log_file.write(error_msg)
+        except subprocess.CalledProcessError as e:
+            error_msg = str(e.output.decode('utf-8'))
+            clangtool_log_file = 'sub_clangjudge_{}.log'.format(sub_info[1])
+            with open('tmp/' + clangtool_log_file, "w") as log_file:
+                log_file.write(error_msg)
 
 # First compile
 try:

--- a/content/compile_and_test.py
+++ b/content/compile_and_test.py
@@ -36,6 +36,7 @@ with open(args.submission_config, "w") as stat_file:
 
 
 # Run clangjudge only for c/c++ submissions
+clangjudge_flag = 0
 if (sub_info[2]==".c" or sub_info[2]==".cpp") and sub_info[3]:
    
     isFileBinary=is_binary('submissions/submission_{}{}'.format(sub_info[1], sub_info[2]))
@@ -54,6 +55,7 @@ if (sub_info[2]==".c" or sub_info[2]==".cpp") and sub_info[3]:
             clangtool_log_file = 'sub_clangjudge_{}.log'.format(sub_info[1])
             with open('tmp/' + clangtool_log_file, "w") as log_file:
                 log_file.write(error_msg)
+            clangjudge_flag = 1
 
 # First compile
 try:
@@ -73,5 +75,15 @@ except subprocess.CalledProcessError as e:  # If compilation fails, end this scr
                             .format(testcase_id,
                                     'CE' if e.returncode == 1 else 'NA', log_file_name))
 else:
-    subprocess.call(['./main_tester.sh'] + sub_info[0:2] + sub_info[4:])  # run tests
+    if clangjudge_flag == 0:
+        subprocess.call(['./main_tester.sh'] + sub_info[0:2] + sub_info[4:])  # run tests
+    else:
+        with open(args.submission_config, "a") as stat_file:
+            for testcase_id in sub_info[6:]:
+                log_file_name = 'sub_run_{}_{}.log'.format(sub_info[1], testcase_id)
+
+                with open('tmp/' + log_file_name, "w") as log_file:
+                    log_file.write("Clang Checks failed. Program uses function that is not allowed.")
+
+                stat_file.write("{} {} 0 0 {}\n".format(testcase_id, 'F', log_file_name))
     subprocess.call(['rm', 'submissions/submission_{}'.format(sub_info[1])])  # remove executable

--- a/content/compile_and_test.py
+++ b/content/compile_and_test.py
@@ -63,7 +63,10 @@ try:
                              'submission_{}{}'.format(sub_info[1], sub_info[2])],
                             stderr=subprocess.STDOUT)
 except subprocess.CalledProcessError as e:  # If compilation fails, end this script here
-    error_msg = str(e.output.decode('utf-8'))
+    if isFileBinary:
+        error_msg = "Submitted file has invalid format."
+    else:
+        error_msg = str(e.output.decode('utf-8'))
     with open(args.submission_config, "a") as stat_file:
         for testcase_id in sub_info[6:]:
             log_file_name = 'sub_run_{}_{}.log'.format(sub_info[1], testcase_id)

--- a/content/compile_and_test.py
+++ b/content/compile_and_test.py
@@ -56,37 +56,40 @@ if (sub_info[2]==".c" or sub_info[2]==".cpp") and sub_info[3]:
             with open('tmp/' + clangtool_log_file, "w") as log_file:
                 log_file.write(error_msg)
             clangjudge_flag = 1
+            with open(args.submission_config, "a") as stat_file:
+                log_file_name = 'sub_run_{}_{}.log'.format(sub_info[1], sub_info[6])
+
+                with open('tmp/' + log_file_name, "w") as log_file:
+                    log_file.write("Clang Checks failed. Program uses function that is not allowed.")
+
+                stat_file.write("{} {} 0 0 {}\n".format(sub_info[6], 'CE2', log_file_name))
+                for testcase_id in sub_info[7:]:
+                    stat_file.write("{}\n".format(testcase_id))
 
 # First compile
-try:
-    subprocess.check_output(['./main_compiler.sh', sub_info[0],
-                             'submission_{}{}'.format(sub_info[1], sub_info[2])],
-                            stderr=subprocess.STDOUT)
-except subprocess.CalledProcessError as e:  # If compilation fails, end this script here
-    if isFileBinary:
-        error_msg = "Submitted file has invalid format."
-    else:
-        error_msg = str(e.output.decode('utf-8'))
-    with open(args.submission_config, "a") as stat_file:
-        for testcase_id in sub_info[6:]:
-            log_file_name = 'sub_run_{}_{}.log'.format(sub_info[1], testcase_id)
+if clangjudge_flag == 0:
+    try:
+        subprocess.check_output(['./main_compiler.sh', sub_info[0],
+                                'submission_{}{}'.format(sub_info[1], sub_info[2])],
+                                stderr=subprocess.STDOUT)
+    except subprocess.CalledProcessError as e:  # If compilation fails, end this script here
+        if isFileBinary or e.returncode == 2:
+            error_msg = "Submitted file has invalid format."
+            verdict_type = 'CE1'
+        else:
+            error_msg = str(e.output.decode('utf-8'))
+            verdict_type = 'CE0'
+
+        with open(args.submission_config, "a") as stat_file:
+            log_file_name = 'sub_run_{}_{}.log'.format(sub_info[1], sub_info[6])
 
             with open('tmp/' + log_file_name, "w") as log_file:
                 log_file.write(error_msg)
 
             stat_file.write("{} {} 0 0 {}\n"
-                            .format(testcase_id,
-                                    'CE' if e.returncode == 1 else 'NA', log_file_name))
-else:
-    if clangjudge_flag == 0:
-        subprocess.call(['./main_tester.sh'] + sub_info[0:2] + sub_info[4:])  # run tests
+                            .format(sub_info[6], verdict_type, log_file_name))
+            for testcase_id in sub_info[7:]:
+                stat_file.write("{}\n".format(testcase_id))
     else:
-        with open(args.submission_config, "a") as stat_file:
-            for testcase_id in sub_info[6:]:
-                log_file_name = 'sub_run_{}_{}.log'.format(sub_info[1], testcase_id)
-
-                with open('tmp/' + log_file_name, "w") as log_file:
-                    log_file.write("Clang Checks failed. Program uses function that is not allowed.")
-
-                stat_file.write("{} {} 0 0 {}\n".format(testcase_id, 'F', log_file_name))
-    subprocess.call(['rm', 'submissions/submission_{}'.format(sub_info[1])])  # remove executable
+        subprocess.call(['./main_tester.sh'] + sub_info[0:2] + sub_info[4:])  # run tests
+        subprocess.call(['rm', 'submissions/submission_{}'.format(sub_info[1])])  # remove executable

--- a/content/judgeClangTool/src/test.cpp
+++ b/content/judgeClangTool/src/test.cpp
@@ -73,16 +73,14 @@ public:
   }
 
   bool VisitCallExpr(CallExpr *cl) {
-    // Only function definitions (with bodies), not declarations.
     auto FuncDecl = cl->getDirectCallee();
     if(StringAllChecks){
      for (int i = 0; i < strFunlength; i++) {
 	if (FuncDecl && FuncDecl->getNameInfo().getAsString() == strFuncs[i]) {
-        // if (Context->getSourceManager().isInMainFile(f->getLocation()))
-        // llvm::outs() << f->getNameInfo().getAsString() << "\n";
-         if (Context->getSourceManager().isInSystemHeader(FuncDecl->getLocation()))
-          // llvm::outs() << FuncDecl->getNameInfo().getAsString() << "\n";
+       	   if (Context->getSourceManager().isInSystemHeader(FuncDecl->getLocation())){
+             llvm::outs() << FuncDecl->getNameInfo().getAsString() << "\n";
              printMsg(cl,strFuncs[i],StringFailType);
+	   }
         }
       }
     }
@@ -106,9 +104,10 @@ public:
     }
     if(SystemAllChecks){
      for (int i = 0; i < sysFunlength; i++) {
-         if (FuncDecl && FuncDecl->getNameInfo().getAsString() == sysFuncs[i]) {
-           if (Context->getSourceManager().isInSystemHeader(FuncDecl->getLocation()))
-               printMsg(cl,sysFuncs[i],SysFailType);
+        if (FuncDecl && FuncDecl->getNameInfo().getAsString() == sysFuncs[i]) {
+	   if (Context->getSourceManager().isInSystemHeader(FuncDecl->getLocation()) || FuncDecl->isImplicit()){
+	       printMsg(cl,sysFuncs[i],SysFailType);
+	   }
          }
        }
      }

--- a/content/main_compiler.sh
+++ b/content/main_compiler.sh
@@ -12,6 +12,7 @@
 # All Error Codes pertaining to Compilation
 SUCCESS=0
 FAILURE=1
+FORMAT_FAIL=2
 
 SUB_FDR="submissions"
 PROB_FDR="problems"
@@ -27,11 +28,14 @@ SUBPATH=${SUB_FDR}/${SUB_FILE}
 EXECPATH=${SUBPATH%.*}
 
 if ! file --mime -b ${SUBPATH} | grep -i -q "ascii" ; then  # checking for ASCII source files
-    return $FAILURE
+    return $FORMAT_FAIL
 fi
 
 case "$SUBPATH" in
     *.c)
+        if ! file --mime -b ${SUBPATH} | grep -i -q "x-c;" ; then  # checking for C source files
+            return $FORMAT_FAIL
+        fi
         EXTENSION=".c"
         compile_c $SUBPATH $EXECPATH
         if [ -e $EXECPATH ] ; then
@@ -41,6 +45,9 @@ case "$SUBPATH" in
         fi
         ;;
     *.cpp)
+        if ! file --mime -b ${SUBPATH} | grep -i -q "x-c++;" ; then  # checking for C++ source files
+            return $FORMAT_FAIL
+        fi
         EXTENSION=".cpp"
         compile_cpp $SUBPATH $EXECPATH
         if [ -e $EXECPATH ] ; then
@@ -50,6 +57,7 @@ case "$SUBPATH" in
         fi
         ;;
     *.py)
+        #TODO: Check for Python file
         EXTENSION=".py"
         compile_py $SUBPATH $EXECPATH
         if [ -e $EXECPATH ] ; then
@@ -59,6 +67,7 @@ case "$SUBPATH" in
         fi
         ;;
     *.go)
+        #TODO: Check for Go file
         EXTENSION=".go"
         compile_go $SUBPATH $EXECPATH
         if [ -e $EXECPATH ] ; then
@@ -68,6 +77,7 @@ case "$SUBPATH" in
         fi
         ;;
     *.hs)
+        #TODO: Check for Haskell file
         EXTENSION=".hs"
         compile_hs $SUBPATH $EXECPATH
         if [ -e $EXECPATH ] ; then

--- a/content/main_tester.sh
+++ b/content/main_tester.sh
@@ -150,7 +150,10 @@ run_submission() {
     
     case "$?" in
       "0")
-          echo "" >> ${TMP}/sub_output_${SID}_${TID}.txt
+          fileSize=$(wc -c < "${TMP}/sub_output_${SID}_${TID}.txt")
+          if [ "$fileSize" -le 1 ] ; then
+            echo -n " " >> ${TMP}/sub_output_${SID}_${TID}.txt
+          fi
           if ! file --mime -b ${TMP}/sub_output_${SID}_${TID}.txt | grep -i -q "ascii" ; then  # checking for ASCII output file
             echo "Output has invalid text" > ${TMP}/sub_run_${SID}_${TID}.log
             VERDICT=$(error_code_to_string $RE ${TID})

--- a/content/main_tester.sh
+++ b/content/main_tester.sh
@@ -150,6 +150,7 @@ run_submission() {
     
     case "$?" in
       "0")
+          echo "" >> ${TMP}/sub_output_${SID}_${TID}.txt
           if ! file --mime -b ${TMP}/sub_output_${SID}_${TID}.txt | grep -i -q "ascii" ; then  # checking for ASCII output file
             echo "Output has invalid text" > ${TMP}/sub_run_${SID}_${TID}.log
             VERDICT=$(error_code_to_string $RE ${TID})

--- a/content/main_tester.sh
+++ b/content/main_tester.sh
@@ -83,16 +83,19 @@ run_submission() {
   # -w /dev/null pipes output of the tool to /dev/null, --vsize-limit gives the virtual size limit
   # --cores 0 limits to only one core,
   # --var provides a file with specific flags which are used for checking
+  # Can use --input, -o flags instead of redirection
   # The last line runs the process
   timeout -s 15 $TLIMIT timer_tool -w /dev/null --vsize-limit $MLIMIT --cores 0 \
              --var ${TMP}/submission_status_${SID}_${TID}.txt \
-             ${SUB_FDR}/submission_${SID} < ${TEST_FDR}/inputfile_${TID}.txt > ${TMP}/sub_output_${SID}_${TID}.txt 2> /dev/null & #Run this in background
+             ${SUB_FDR}/submission_${SID} < ${TEST_FDR}/inputfile_${TID}.txt > ${TMP}/sub_output_${SID}_${TID}.txt 2> ${TMP}/sub_run_${SID}_${TID}.log & #Run this in background
   
   limit_proc_id=$! #Getting PID of background process
   
   wasNotFound=0 #Setting flag to poll background process
 
   #Polling background process
+  #Can use --output-limit flag of timer_tool
+  #But this is faster as it terminates as soon as size limit is reached
   while [ "$wasNotFound" != 1 ] 
   do
 	  ps | grep -q "$limit_proc_id"
@@ -145,10 +148,7 @@ run_submission() {
     
   #If no limit was exceeded normal flow resumes
   if [ "$LIMITFLAG" = 0 ] ; then
-    clean_generated_output ${SID} ${TID}  # Delete the generated file to prevent any mismatch
-    ${SUB_FDR}/submission_${SID} < ${TEST_FDR}/inputfile_${TID}.txt > ${TMP}/sub_output_${SID}_${TID}.txt 2> ${TMP}/sub_run_${SID}_${TID}.log
-    
-    case "$?" in
+    case "$EXITSTATUS" in
       "0")
           fileSize=$(wc -c < "${TMP}/sub_output_${SID}_${TID}.txt")
           if [ "$fileSize" -le 1 ] ; then
@@ -163,7 +163,7 @@ run_submission() {
           fi
           ;;
       *)
-          echo "\nExit code: $?" >> ${TMP}/sub_run_${SID}_${TID}.log
+          echo "\nExit code: $EXITSTATUS" >> ${TMP}/sub_run_${SID}_${TID}.log
           VERDICT=$(error_code_to_string $RE ${TID})
           ;;
     esac

--- a/content/main_tester.sh
+++ b/content/main_tester.sh
@@ -143,8 +143,13 @@ run_submission() {
     
     case "$?" in
       "0")
-          ./${PROB_FDR}/${PROB_CODE}/test_script ${TEST_FDR}/outputfile_${TID}.txt ${TMP}/sub_output_${SID}_${TID}.txt > /dev/null
-          VERDICT=$(error_code_to_string $? ${TID})
+          if ! file --mime -b ${TMP}/sub_output_${SID}_${TID}.txt | grep -i -q "ascii" ; then  # checking for ASCII output file
+            echo "Output has invalid text" > ${TMP}/sub_run_${SID}_${TID}.log
+            VERDICT=$(error_code_to_string $RE ${TID})
+          else
+            ./${PROB_FDR}/${PROB_CODE}/test_script ${TEST_FDR}/outputfile_${TID}.txt ${TMP}/sub_output_${SID}_${TID}.txt > /dev/null
+            VERDICT=$(error_code_to_string $? ${TID})
+          fi
           ;;
       *)
           echo "\nExit code: $?" >> ${TMP}/sub_run_${SID}_${TID}.log

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -99,6 +99,11 @@ class NewContestForm(forms.Form):
     is_public = forms.BooleanField(label='Is this contest public?', required=False)
     """Contest is_public property"""
 
+    enable_evaluation = forms.BooleanField(label='Enable evaluations for submissions',
+                                             required=False,
+                                             initial=True)
+    """Contest enable_evaluation property"""
+
     enable_leaderboard = forms.BooleanField(label='Enable leaderboard', required=False,
                                              initial=True)
     """Contest enable_leaderboard property"""

--- a/judge/forms.py
+++ b/judge/forms.py
@@ -96,13 +96,6 @@ class NewContestForm(forms.Form):
                                  help_text='Enter a penalty factor between 0 and 1.')
     """Contest Penalty factor"""
 
-    submission_limit = forms.IntegerField(label='Submission Limit', min_value=1,
-                                 max_value=1000,
-                                 widget=forms.NumberInput(attrs={'class': 'form-control'}),
-                                 help_text='Enter the maximum number of submissions allowed \
-                                            for each participant (between 1 and 1000).')
-    """Contest Submission Limit"""
-
     is_public = forms.BooleanField(label='Is this contest public?', required=False)
     """Contest is_public property"""
 
@@ -244,16 +237,23 @@ class NewProblemForm(forms.Form):
 
     time_limit = forms.DurationField(label='Time Limit (in milliseconds)',
                                      widget=forms.NumberInput(attrs={'class': 'form-control'}),
-                                     initial=0, help_text='Specify a time limit in milliseconds \
+                                     initial=1000, help_text='Specify a time limit in milliseconds \
                                                            for the execution of the program.')
     """Problem Time limit"""
 
     memory_limit = forms.IntegerField(label='Memory Limit (in KB)',
                                       widget=forms.NumberInput(attrs={'class': 'form-control'}),
-                                      initial=0, min_value=0,
+                                      initial=10240, min_value=0,
                                       help_text='Specify a memory limit in MB for the execution \
                                                  of the program.If not specified(set to 0) memory limit will default to 1 KB')
     """Problem Memory limit"""
+
+    submission_limit = forms.IntegerField(label='Submission Limit', min_value=1,
+                                 max_value=1000, required=False, initial=1000,
+                                 widget=forms.NumberInput(attrs={'class': 'form-control'}),
+                                 help_text='Enter the maximum number of submissions allowed \
+                                            for each participant (between 1 and 1000).')
+    """Contest Submission Limit"""
 
     file_exts = forms.CharField(label='Permitted File extensions for submissions',
                                 widget=forms.TextInput(attrs={'class': 'form-control'}),
@@ -340,6 +340,14 @@ class EditProblemForm(forms.Form):
                                                the problem. If this is unknown, leave it as 0.')
     """Problem Difficulty Field"""
 
+class CloseProblemForm(forms.Form):
+    """
+    Form for closing submissions for a problem.
+    """
+    is_closed = forms.BooleanField(label='Close submissions', required=False,
+                                   help_text='Specify whether submissions for the problem \
+                                              should be closed.')
+    """Problem is_closed property"""
 
 class NewSubmissionForm(forms.Form):
     """

--- a/judge/handler.py
+++ b/judge/handler.py
@@ -45,7 +45,7 @@ def update_index_string(index_str: str, index_str_plural: str) -> Tuple[bool, Va
 
 
 def process_contest(contest_name: str, contest_start: datetime, contest_soft_end: datetime,
-                    contest_hard_end: datetime, penalty: float, submission_limit: int,
+                    contest_hard_end: datetime, penalty: float,
                     is_public: bool,
                     enable_leaderboard: bool,
                     enable_linter_score: bool,
@@ -58,8 +58,6 @@ def process_contest(contest_name: str, contest_start: datetime, contest_soft_end
     :param contest_soft_end: A `datetime` object representing the soft deadline of the contest
     :param contest_hard_end: A `datetime` object representing the hard deadline of the contest
     :param penalty: A penalty score for late submissions
-    :param submission_limit: Integer representing maximum number of submissions allowed
-                             for each participant
     :param is_public: Field to indicate if the contest is public (or private)
     :param enable_leaderboard: Field to indicate if leaderboard is to be maintained
     :param enable_linter_score: Field to indicate if linter scoring is enabled in the contest
@@ -78,7 +76,6 @@ def process_contest(contest_name: str, contest_start: datetime, contest_soft_end
                                                     soft_end_datetime=contest_soft_end,
                                                     hard_end_datetime=contest_hard_end,
                                                     penalty=penalty,
-                                                    submission_limit=submission_limit,
                                                     public=is_public,
                                                     enable_leaderboard=enable_leaderboard,
                                                     enable_linter_score=enable_linter_score,
@@ -153,6 +150,8 @@ def process_problem(contest_id: int,
     :type statement: int
     :param memory_limit: Problem virtual memory limit
     :type statement: int
+    :param submission_limit: Integer representing maximum number of submissions allowed
+                             for each participant
     :param file_exts: Accepted file format for submissions
     :type statement: str
     :param clang_checks: Placeholder clang checks

--- a/judge/handler.py
+++ b/judge/handler.py
@@ -47,6 +47,7 @@ def update_index_string(index_str: str, index_str_plural: str) -> Tuple[bool, Va
 def process_contest(contest_name: str, contest_start: datetime, contest_soft_end: datetime,
                     contest_hard_end: datetime, penalty: float,
                     is_public: bool,
+                    enable_evaluation: bool,
                     enable_leaderboard: bool,
                     enable_linter_score: bool,
                     enable_poster_score: bool) -> Tuple[bool, Union[ValidationError, str]]:
@@ -59,6 +60,7 @@ def process_contest(contest_name: str, contest_start: datetime, contest_soft_end
     :param contest_hard_end: A `datetime` object representing the hard deadline of the contest
     :param penalty: A penalty score for late submissions
     :param is_public: Field to indicate if the contest is public (or private)
+    :param enable_evaluation: Field to indicate if submissions should be evaluated
     :param enable_leaderboard: Field to indicate if leaderboard is to be maintained
     :param enable_linter_score: Field to indicate if linter scoring is enabled in the contest
     :param enable_poster_score: Field to indicate if poster scoring is enabled in the contest
@@ -77,6 +79,7 @@ def process_contest(contest_name: str, contest_start: datetime, contest_soft_end
                                                     hard_end_datetime=contest_hard_end,
                                                     penalty=penalty,
                                                     public=is_public,
+                                                    enable_evaluation=enable_evaluation,
                                                     enable_leaderboard=enable_leaderboard,
                                                     enable_linter_score=enable_linter_score,
                                                     enable_poster_score=enable_poster_score)
@@ -522,26 +525,27 @@ def process_submission(problem_id: str, participant_id: str, file_type: str,
 
     testcases = models.TestCase.objects.filter(problem=problem)
 
-    if not os.path.exists(os.path.join('content', 'tmp')):
-        os.makedirs(os.path.join('content', 'tmp'))
-    # NB: File structure here
-    # PROBLEM_ID
-    # SUBMISSION_ID
-    # FILE_FORMAT
-    # TIME_LIMIT
-    # MEMORY_LIMIT
-    # TESTCASE_1
-    # TESTCASE_2
-    # ....
-    with open(os.path.join('content', 'tmp', 'sub_run_' + str(sub.pk) + '.txt'), 'w') as f:
-        f.write('{}\n'.format(problem.pk))
-        f.write('{}\n'.format(sub.pk))
-        f.write('{}\n'.format(file_type))
-        f.write('{}\n'.format(problem.clang_checks))
-        f.write('{}\n'.format((problem.time_limit.total_seconds())))
-        f.write('{}\n'.format(problem.memory_limit))
-        for testcase in testcases:
-            f.write('{}\n'.format(testcase.pk))
+    if problem.contest.enable_evaluation:
+        if not os.path.exists(os.path.join('content', 'tmp')):
+            os.makedirs(os.path.join('content', 'tmp'))
+        # NB: File structure here
+        # PROBLEM_ID
+        # SUBMISSION_ID
+        # FILE_FORMAT
+        # TIME_LIMIT
+        # MEMORY_LIMIT
+        # TESTCASE_1
+        # TESTCASE_2
+        # ....
+        with open(os.path.join('content', 'tmp', 'sub_run_' + str(sub.pk) + '.txt'), 'w') as f:
+            f.write('{}\n'.format(problem.pk))
+            f.write('{}\n'.format(sub.pk))
+            f.write('{}\n'.format(file_type))
+            f.write('{}\n'.format(problem.clang_checks))
+            f.write('{}\n'.format((problem.time_limit.total_seconds())))
+            f.write('{}\n'.format(problem.memory_limit))
+            for testcase in testcases:
+                f.write('{}\n'.format(testcase.pk))
 
     try:
         for testcase in testcases:

--- a/judge/models.py
+++ b/judge/models.py
@@ -70,9 +70,6 @@ class Contest(models.Model):
     penalty = models.FloatField(default=0.0)
     """Penalty for late-submission"""
 
-    submission_limit = models.PositiveSmallIntegerField(default=1000)
-    """Maximum number of submissions allowed for each participant"""
-
     public = models.BooleanField(default=False)
     """Is the contest public?"""
 
@@ -128,6 +125,9 @@ class Problem(models.Model):
     memory_limit = models.PositiveIntegerField(default=200000)
     """Problem memory limit"""
 
+    submission_limit = models.PositiveSmallIntegerField(default=1000)
+    """Maximum number of submissions allowed for each participant"""
+
     # Support upto 30 file formats
     file_exts = models.CharField(max_length=100, default='.py,.cpp')
     """Accepted file extensions for submissions to problem"""
@@ -152,6 +152,9 @@ class Problem(models.Model):
                           is_compilation=False),
         default='./default/test_script.sh')
     """Problem test script"""
+
+    is_closed = models.BooleanField(default=False)
+    """Close Problem Submissions"""
 
     def __str__(self):
         return self.code

--- a/judge/models.py
+++ b/judge/models.py
@@ -73,6 +73,9 @@ class Contest(models.Model):
     public = models.BooleanField(default=False)
     """Is the contest public?"""
 
+    enable_evaluation = models.BooleanField(default=True)
+    """Enable submission evaluation"""
+
     enable_leaderboard = models.BooleanField(default=True)
     """Enable leaderboard"""
 

--- a/judge/models.py
+++ b/judge/models.py
@@ -211,6 +211,9 @@ class Submission(models.Model):
     timestamp = models.DateTimeField()
     """Timestamp of submission"""
 
+    verdict_type = models.TextField(default='')
+    """Categorize verdicts into verdict_type for a submission"""
+
     clang_tool_msg = models.TextField(default='')
     """Message placeholder, used for displaying clang tool output"""
 

--- a/judge/templates/judge/problem_detail.html
+++ b/judge/templates/judge/problem_detail.html
@@ -78,7 +78,8 @@
     statementQuill.disable()
     inputFormatQuill.disable()
     outputFormatQuill.disable()
-
+</script>
+<script>
     $(document).ready(function () {
         $(".custom-file-input").on("change", function () {
             var fileName = $(this).val().split("\\").pop();
@@ -143,14 +144,14 @@
         </div>
         {% endif %}
     </div>
-    {% if type == 'Poster' %}
+    {% if type == 'Poster' and curr_time > problem.contest.start_datetime and curr_time < problem.contest.hard_end_datetime %}
     <div class="modal fade" id="modal-close-problem" tabindex="-1" role="dialog" aria-hidden="true">
         <div class="modal-dialog modal- modal-dialog-centered modal-sm" role="document">
             <div class="modal-content">
                 <div class="modal-body p-0">
                     <div class="card bg-secondary shadow border-0">
                         <div class="card-body px-lg-5 py-lg-5">
-                            <div class="text-center text-muted mb-4">Update {{ index_string }}</div>
+                            <div class="text-center text-muted mb-4">Close Submissions</div>
                             <form method="POST" role="form">
                                 {% if form.non_field_errors %}
                                 {% for nfe in form.non_field_errors %}

--- a/judge/templates/judge/problem_detail.html
+++ b/judge/templates/judge/problem_detail.html
@@ -109,6 +109,13 @@
     });
 
 </script>
+{% if form.errors %}
+<script>
+    $(window).on('load', function () {
+        $('#modal-close-problem').modal('show');
+    });
+</script>
+{% endif %}
 {% endblock %}
 
 {% block content %}
@@ -123,15 +130,61 @@
             <a href="{% url 'judge:edit_problem' problem.pk %}" class="btn btn-primary">
                 <i class="fas fa-edit"></i>
             </a>
-            {% if curr_time < problem.contest.start_datetime %}
+            {% if curr_time < problem.contest.start_datetime or problem.is_closed %}
             <form class="d-inline" action="{% url 'judge:delete_problem' problem.pk %}" method="POST">
                 {% csrf_token %}
                 <button type="submit" class="btn btn-danger"><i class="fas fa-trash"></i></button>
             </form>
             {% endif %}
+            {% if curr_time > problem.contest.start_datetime and curr_time < problem.contest.hard_end_datetime %}
+            <button type="button" class="btn btn-primary my-1 btn-sm" data-toggle="modal"
+                data-target="#modal-close-problem">Close Problem</button>
+            {% endif %}
         </div>
         {% endif %}
     </div>
+    {% if type == 'Poster' %}
+    <div class="modal fade" id="modal-close-problem" tabindex="-1" role="dialog" aria-hidden="true">
+        <div class="modal-dialog modal- modal-dialog-centered modal-sm" role="document">
+            <div class="modal-content">
+                <div class="modal-body p-0">
+                    <div class="card bg-secondary shadow border-0">
+                        <div class="card-body px-lg-5 py-lg-5">
+                            <div class="text-center text-muted mb-4">Update {{ index_string }}</div>
+                            <form method="POST" role="form">
+                                {% if form.non_field_errors %}
+                                {% for nfe in form.non_field_errors %}
+                                <div class="alert alert-danger mt-2" role="alert">
+                                        {{ nfe }}
+                                </div>
+                                {% endfor %}
+                                {% endif %}
+                                {% csrf_token %}
+                                {% for field in form %}
+                                <div class="form-group mb-1">
+                                    {{ field.label_tag }}
+                                    {{ field }}
+                                    {% if field.help_text %}
+                                    <small class="form-text text-muted">{{ field.help_text|safe }}</small>
+                                    {% endif %}
+                                    {% if field.errors %}
+                                    <div class="alert alert-danger mt-2" role="alert">
+                                        {{ field.errors|striptags }}
+                                    </div>
+                                    {% endif %}
+                                </div>
+                                {% endfor %}
+                                <div class="text-center">
+                                    <button type="submit" class="btn btn-primary my-4">Update</button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    {% endif %}
     <div class="col-12 my-4">
         <h4 class="">Statement</h4>
         <div id="statementEditor"></div>
@@ -162,6 +215,10 @@
                 <tr>
                     <th>Memory limit</th>
                     <td>{{ problem.memory_limit }} KB</td>
+                </tr>
+                <tr>
+                    <th>Submission limit</th>
+                    <td>{{ problem.submission_limit }}</td>
                 </tr>
                 <tr>
                     <th>Allowed file extensions</th>
@@ -252,7 +309,8 @@
                 <h3>Submit Solution</h3>
             </div>
             {% if curr_time < problem.contest.hard_end_datetime %}
-            {% if user_submission_num <= problem.contest.submission_limit %}
+            {% if not problem.is_closed %}
+            {% if user_submission_num <= problem.submission_limit %}
             <div class="card-body">
                 <form method="POST" enctype="multipart/form-data">
                     {% if form.non_field_errors %}
@@ -304,7 +362,12 @@
             {% endif %}
             {% else %}
             <div class="card-body">
-            <H2>Submissions Over!</H2>
+                <H2>Submissions Closed!</H2>
+            </div>
+            {% endif %}
+            {% else %}
+            <div class="card-body">
+                <H2>Submissions Over!</H2>
             </div>
             {% endif %}
         </div>

--- a/judge/templates/judge/problem_submissions.html
+++ b/judge/templates/judge/problem_submissions.html
@@ -12,11 +12,18 @@
 {% block content %}
 
 {% if not participant %}
-<div style="text-align: right;">    
-    <a style="background-color: #5e72e4; margin: 0 0;" href="{% url 'judge:all_submissions_download' problem.code %}" class="btn btn-icon btn-default">
+<div style="text-align: right; padding-bottom: 5px;">
+    <a style="background-color: #5e72e4; margin: 0 0;" href="{% url 'judge:all_submissions_download' problem.code 0 %}" class="btn btn-icon btn-default">
         Download All Latest Submissions
     </a>
 </div>
+{% if problem.contest.enable_evaluation %}
+<div style="text-align: right;">
+    <a style="margin: 0 0;" href="{% url 'judge:all_submissions_download' problem.code 1 %}" class="btn btn-icon btn-default">
+        Download Failed Check Submissions
+    </a>
+</div>
+{% endif %}
 {% endif %}
 
 {% for email, subs in submissions.items %}
@@ -43,12 +50,12 @@
                         {% if forloop.first %}
                         <span class="badge badge-pill badge-primary">Public</span>
                         {% endif %}
-                        {% if result == 'Passed' %}
+                        {% if result == 'Internal Failure' or not problem.contest.enable_evaluation %}
+                        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAk0lEQVRIie2T2w2AIAxFu4lshBvpBrBB2fT6ccOPmlCKGk08Sf9oT+hD5OfT5AysK5AzcGlhVSAEQOQYIQClDArn+bz4PvjOQYw2gVuk2ieowTwj0+STcHZmfBKGgZRGBADzGyzLmIT5b/gJuXkmIv7tYp6RR+5EpP/i+d6BVeQWVFRrr89n0N2iFinxDjrW9OelbNPkxjL/y6yXAAAAAElFTkSuQmCC"/>
+                        {% elif result == 'Passed' %}
                         <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAsklEQVRIie2VwQnDMAxFNZA9lskM8gzKWjp1FF+SBV4vNZSStrYTQgv58K962PqSRC79rRwnk5mYyGQc57DihiGrILcNr8LMPA4rFCJxu/iLI5FC6YcFQhPgGdQFMKwLUG1YB2jpB9QeNdV3fAzwcFPqFN0FUfQ7JJF2QRLpR15ySk9EZDxdS2O6RM6aE+mf+EDoXyuFQisoEMZ2V5VhvO3RMvBFn+Q4ipJIKHrsPbl0uu69ccamwMCGAQAAAABJRU5ErkJggg=="/>
                         {% elif result == 'Running' %}
                         <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAvElEQVRIie3VOw6DMAyAYd8EbgQ3ghskN0g3uAXd0s29RUZGxr8Doqr6UhIQaiUsWdnyKYntiBzxt0FQuFg4t/MalO02Vwe2hFZe05ZwPeVjTCP09fvNn7OvYRrTMboqDniA0gB1acCS6uIhTJGH2DIOIWgesGRM1eHNOsSbCGRo1iFD8ysn2eNNRFZUlykSSniPPhGR9I7vqoyxMo1EQ12VN7vumDo+vpEp0q/oKxYUvIGhmdct/5Mjdo8bzt1WcfA88JMAAAAASUVORK5CYII="/>
-                        {% elif result == 'Internal Failure' %}
-                        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAk0lEQVRIie2T2w2AIAxFu4lshBvpBrBB2fT6ccOPmlCKGk08Sf9oT+hD5OfT5AysK5AzcGlhVSAEQOQYIQClDArn+bz4PvjOQYw2gVuk2ieowTwj0+STcHZmfBKGgZRGBADzGyzLmIT5b/gJuXkmIv7tYp6RR+5EpP/i+d6BVeQWVFRrr89n0N2iFinxDjrW9OelbNPkxjL/y6yXAAAAAElFTkSuQmCC"/>
                         {% else %}
                         <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAyUlEQVRIie2VTQrEIAyFcxO9kd7I3iC9QXqggYBrtx0QBHeuCplVYZhftaXMQB+8bT40LwnAqb9VYZY4jnIdBonjKIVZdiueiMRrLReAJ3utJU1TP2zJWYK1L4s/OlgrS87tsGBMFeAe1ARIRE2A1YmoHuSV6oJ4resghbkLsLoqdRFxEyQifofMzm2CzM79yEsO6QnAhnQpVR/hQ+YEoGPijWlfK0vOUgsKxvTtrlWJSN71yCvV/kWfVJglIsrsnETEfe/JqcN1A4nmyrwH5iNHAAAAAElFTkSuQmCC"/>
                         {% endif %}
@@ -60,12 +67,12 @@
                         {% endif %}
                         <span class="badge badge-pill badge-default">Private</span>
                         {% endif %}
-                        {% if result == 'Passed' %}
+                        {% if result == 'Internal Failure' or not problem.contest.enable_evaluation %}
+                        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAk0lEQVRIie2T2w2AIAxFu4lshBvpBrBB2fT6ccOPmlCKGk08Sf9oT+hD5OfT5AysK5AzcGlhVSAEQOQYIQClDArn+bz4PvjOQYw2gVuk2ieowTwj0+STcHZmfBKGgZRGBADzGyzLmIT5b/gJuXkmIv7tYp6RR+5EpP/i+d6BVeQWVFRrr89n0N2iFinxDjrW9OelbNPkxjL/y6yXAAAAAElFTkSuQmCC"/>
+                        {% elif result == 'Passed' %}
                         <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAsklEQVRIie2VwQnDMAxFNZA9lskM8gzKWjp1FF+SBV4vNZSStrYTQgv58K962PqSRC79rRwnk5mYyGQc57DihiGrILcNr8LMPA4rFCJxu/iLI5FC6YcFQhPgGdQFMKwLUG1YB2jpB9QeNdV3fAzwcFPqFN0FUfQ7JJF2QRLpR15ySk9EZDxdS2O6RM6aE+mf+EDoXyuFQisoEMZ2V5VhvO3RMvBFn+Q4ipJIKHrsPbl0uu69ccamwMCGAQAAAABJRU5ErkJggg=="/>
                         {% elif result == 'Running' %}
                         <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAvElEQVRIie3VOw6DMAyAYd8EbgQ3ghskN0g3uAXd0s29RUZGxr8Doqr6UhIQaiUsWdnyKYntiBzxt0FQuFg4t/MalO02Vwe2hFZe05ZwPeVjTCP09fvNn7OvYRrTMboqDniA0gB1acCS6uIhTJGH2DIOIWgesGRM1eHNOsSbCGRo1iFD8ysn2eNNRFZUlykSSniPPhGR9I7vqoyxMo1EQ12VN7vumDo+vpEp0q/oKxYUvIGhmdct/5Mjdo8bzt1WcfA88JMAAAAASUVORK5CYII="/>
-                        {% elif result == 'Internal Failure' %}
-                        <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAk0lEQVRIie2T2w2AIAxFu4lshBvpBrBB2fT6ccOPmlCKGk08Sf9oT+hD5OfT5AysK5AzcGlhVSAEQOQYIQClDArn+bz4PvjOQYw2gVuk2ieowTwj0+STcHZmfBKGgZRGBADzGyzLmIT5b/gJuXkmIv7tYp6RR+5EpP/i+d6BVeQWVFRrr89n0N2iFinxDjrW9OelbNPkxjL/y6yXAAAAAElFTkSuQmCC"/>
                         {% else %}
                         <img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABkAAAAZCAYAAADE6YVjAAAAyUlEQVRIie2VTQrEIAyFcxO9kd7I3iC9QXqggYBrtx0QBHeuCplVYZhftaXMQB+8bT40LwnAqb9VYZY4jnIdBonjKIVZdiueiMRrLReAJ3utJU1TP2zJWYK1L4s/OlgrS87tsGBMFeAe1ARIRE2A1YmoHuSV6oJ4resghbkLsLoqdRFxEyQifofMzm2CzM79yEsO6QnAhnQpVR/hQ+YEoGPijWlfK0vOUgsKxvTtrlWJSN71yCvV/kWfVJglIsrsnETEfe/JqcN1A4nmyrwH5iNHAAAAAElFTkSuQmCC"/>
                         {% endif %}

--- a/judge/templates/judge/submission_detail.html
+++ b/judge/templates/judge/submission_detail.html
@@ -144,10 +144,14 @@
                                                 <tr>
                                                     <th>Status</th>
                                                     <td>
+                                                    {% if not problem.contest.enable_evaluation %}
+                                                    <span class="badge badge-pill badge-secondary">Disabled</span>
+                                                    {% else %}
                                                     {% if clangtool_passed %}
                                                     <span class="badge badge-pill badge-success">Passed/Running</span>
                                                     {% else %}
                                                     <span class="badge badge-pill badge-danger">Failed</span>
+                                                    {% endif %}
                                                     {% endif %}
                                                     </td>
                                                 </tr>
@@ -179,7 +183,9 @@
                 {% else %}
                 <span class="badge badge-pill badge-default">Private</span>
                 {% endif %}
-                {% if res.0 == "Passed" %}
+                {% if not problem.contest.enable_evaluation %}
+                <span class="badge badge-pill badge-secondary">Submitted</span>
+                {% elif res.0 == "Passed" %}
                 <span class="badge badge-pill badge-success">{{ res.0 }}</span>
                 {% elif res.0 == "Running" %}
                 <span class="badge badge-pill badge-warning">{{ res.0 }}</span>
@@ -209,6 +215,7 @@
                                                         <th>Test Case ID</th>
                                                         <td>{{ test_id }}</td>
                                                     </tr>
+                                                    {% if problem.contest.enable_evaluation %}
                                                     <tr>
                                                         <th>Status</th>
                                                         <td>{{ res.0 }}</td>
@@ -221,8 +228,15 @@
                                                         <th>Memory taken</th>
                                                         <td>{{ res.2 }} KB</td>
                                                     </tr>
+                                                    {% else %}
+                                                    <tr>
+                                                        <th>Status</th>
+                                                        <td>Submitted</td>
+                                                    </tr>
+                                                    {% endif %}
                                                 </tbody>
                                             </table>
+                                            {% if problem.contest.enable_evaluation %}
                                             {% if res.0 != "Running" %}
                                             {% if type == 'Poster' %}
                                             <p>
@@ -235,6 +249,7 @@
                                                 <b>Message:</b><br>
                                                 <textarea class="form-control" disabled style="height:500px;font-weight:bold;">{{ res.5 }}</textarea>
                                             </p>
+                                            {% endif %}
                                             {% endif %}
                                             {% endif %}
                                             {% endif %}

--- a/judge/templates/judge/submission_detail.html
+++ b/judge/templates/judge/submission_detail.html
@@ -229,8 +229,8 @@
                                                 <b>Message:</b><br>
                                                 <textarea class="form-control" disabled style="height:500px;font-weight:bold;">{{ res.6 }}</textarea>
                                             </p>
-                                            {% elif clangtool_passed or res.0 == "Compilation Error" %}
-                                            {% if res.0 != "Passed" and res.0 != "Failed" or res.3 %}
+                                            {% else %}
+                                            {% if res.0 != "Passed" and res.0 != "Failed" or res.3 or not clangtool_passed %}
                                             <p>
                                                 <b>Message:</b><br>
                                                 <textarea class="form-control" disabled style="height:500px;font-weight:bold;">{{ res.5 }}</textarea>

--- a/judge/tests.py
+++ b/judge/tests.py
@@ -66,7 +66,7 @@ class HandlerTests(TestCase):
                                              contest_start='2019-04-25T12:30',
                                              contest_soft_end='2019-04-26T12:30',
                                              contest_hard_end='2019-04-27T12:30',
-                                             penalty=0, submission_limit=1000, is_public=True,
+                                             penalty=0, is_public=True,
                                              enable_linter_score=True,
                                              enable_leaderboard=True, enable_poster_score=True)
         self.assertTrue(status)
@@ -79,7 +79,6 @@ class HandlerTests(TestCase):
         self.assertEqual(c.soft_end_datetime, datetime(2019, 4, 26, 7, 0, tzinfo=timezone.utc))
         self.assertEqual(c.hard_end_datetime, datetime(2019, 4, 27, 7, 0, tzinfo=timezone.utc))
         self.assertEqual(c.penalty, 0)
-        self.assertEqual(c.submission_limit, 1000)
         self.assertTrue(c.public)
         self.assertTrue(c.enable_leaderboard)
         status, err = handler.delete_contest(contest_id=int(pk))
@@ -98,8 +97,8 @@ class HandlerTests(TestCase):
             statement='Test Problem Statement',
             input_format='Test input format',
             output_format='Test output format', difficulty=5,
-            time_limit=timedelta(seconds=10),
-            memory_limit=10000, file_exts='.py', starting_code=None,
+            time_limit=timedelta(seconds=10), memory_limit=10000,
+            submission_limit=1000, file_exts='.py', starting_code=None,
             max_score=4, compilation_script=None, test_script=None)
         self.assertTrue(status)
         self.assertIsNone(msg)
@@ -114,6 +113,7 @@ class HandlerTests(TestCase):
         self.assertEqual(p.difficulty, 5)
         self.assertEqual(p.time_limit, timedelta(seconds=10))
         self.assertEqual(p.memory_limit, 10000)
+        self.assertEqual(p.submission_limit, 1000)
         self.assertEqual(p.file_exts, '.py')
         self.assertEqual(p.max_score, 4)
         status, msg = handler.update_problem(code=p.code, name='Updated Test Problem 1',

--- a/judge/tests.py
+++ b/judge/tests.py
@@ -68,6 +68,7 @@ class HandlerTests(TestCase):
                                              contest_hard_end='2019-04-27T12:30',
                                              penalty=0, is_public=True,
                                              enable_linter_score=True,
+                                             enable_evaluation=True,
                                              enable_leaderboard=True, enable_poster_score=True)
         self.assertTrue(status)
         c = models.Contest.objects.filter(pk=int(pk))
@@ -80,6 +81,7 @@ class HandlerTests(TestCase):
         self.assertEqual(c.hard_end_datetime, datetime(2019, 4, 27, 7, 0, tzinfo=timezone.utc))
         self.assertEqual(c.penalty, 0)
         self.assertTrue(c.public)
+        self.assertTrue(c.enable_evaluation)
         self.assertTrue(c.enable_leaderboard)
         status, err = handler.delete_contest(contest_id=int(pk))
         self.assertTrue(status)

--- a/judge/urls.py
+++ b/judge/urls.py
@@ -48,7 +48,7 @@ urlpatterns = [
          views.edit_problem, name='edit_problem'),
     path('problem/<str:problem_id>/submissions/',
          views.problem_submissions, name='problem_submissions'),
-    path('submission/<str:problem_id>/downloadlatest/',
+    path('submission/<str:problem_id>/downloadlatest/<int:get_failed>/',
          views.all_submissions_download, name='all_submissions_download'),
 
     # Submission-specific paths

--- a/judge/views.py
+++ b/judge/views.py
@@ -756,7 +756,7 @@ def submission_download(request, submission_id: str):
     else:
         return handler404(request)
 
-def all_submissions_download(request, problem_id: str):
+def all_submissions_download(request, problem_id: str, get_failed: bool):
     """
     Function to provide the facility to download all latest submissions for a given problem.
 
@@ -781,9 +781,11 @@ def all_submissions_download(request, problem_id: str):
         if user is None:
             return handler404(request)
         if perm or user.email == submission.participant:
-            filedir, filename = os.path.split(filepath)
-            zip_path = os.path.join(zip_subdir, filename)
-            zf.write(filepath, zip_path)
+            if ((get_failed and submission.clang_tool_msg) or
+                not (get_failed or submission.clang_tool_msg)):
+                filedir, filename = os.path.split(filepath)
+                zip_path = os.path.join(zip_subdir, filename)
+                zf.write(filepath, zip_path)
         else:
             return handler404(request)
     zf.close()

--- a/judge/views.py
+++ b/judge/views.py
@@ -768,6 +768,14 @@ def all_submissions_download(request, problem_id: str, get_failed: bool):
     user = _get_user(request)
     all_participants = Submission.objects.filter(problem=problem_id).values_list('participant').distinct()
     zip_subdir = problem_id
+    if get_failed:
+        zip_subdir += "-failed"
+    dir_dict = {'CE0': os.path.join(zip_subdir, 'compilation_errs'),
+                'CE1': os.path.join(zip_subdir, 'unknown_format'),
+                'CE2': os.path.join(zip_subdir, 'checks_failed'),
+                'RE0': os.path.join(zip_subdir, 'runtime_errs'),
+                '0': os.path.join(zip_subdir, 'passed'),
+                '': os.path.join(zip_subdir, 'not_evaluated')}
     zip_filename = "{}.zip".format(zip_subdir)
 
     s = BytesIO()
@@ -784,12 +792,12 @@ def all_submissions_download(request, problem_id: str, get_failed: bool):
             if ((get_failed and submission.clang_tool_msg) or
                 not (get_failed or submission.clang_tool_msg)):
                 filedir, filename = os.path.split(filepath)
-                zip_path = os.path.join(zip_subdir, filename)
+                zip_path = os.path.join(dir_dict[submission.verdict_type], filename)
                 zf.write(filepath, zip_path)
         else:
             return handler404(request)
     zf.close()
-    return _return_zip_as_response(s.getvalue(),zip_filename)
+    return _return_zip_as_response(s.getvalue(), zip_filename)
 
 
 

--- a/submission_watcher_saver.py
+++ b/submission_watcher_saver.py
@@ -45,121 +45,142 @@ def saver(sub_id):
         # SUBMISSION_ID
         # TESTCASEID VERDICT TIME MEMORY MESSAGE
         # Read the output into verdict, memory and time.
-        lines = [line[:-1] for line in f.readlines()]
-        problem = lines[0]
-        submission = lines[1]
-        testcase_id, verdict, time, memory, msg = [], [], [], [], []
+        try:
+            lines = [line[:-1] for line in f.readlines()]
+            problem = lines[0]
+            submission = lines[1]
+            testcase_id, verdict, time, memory, msg = [], [], [], [], []
+        except Exception as err:
+            print("Internal Error: Can't read sub txt file")
         for line in lines[2:]:
-            sep = line.split(' ', maxsplit=4)
-            testcase_id.append(sep[0])
-            verdict.append(sep[1])
-            time.append(sep[2])
-            memory.append(sep[3])
-            with open(os.path.join(MONITOR_DIRECTORY, sep[4])) as log_file:
-                msg.append(str(log_file.read()))
-            os.remove(os.path.join(MONITOR_DIRECTORY, sep[4]))  # Remove after reading
+            try:
+                sep = line.split(' ', maxsplit=4)
+                testcase_id.append(sep[0])
+                verdict.append(sep[1])
+                time.append(sep[2])
+                memory.append(sep[3])
+            except Exception as err:
+                print("Internal Error: Can't split sub txt string")
+            try:
+                with open(os.path.join(MONITOR_DIRECTORY, sep[4])) as log_file:
+                    msg.append(str(log_file.read()))
+            except Exception as err:
+                msg.append("Output has invalid text")
+                verdict.pop()
+                verdict.append('RE')
+            try:
+                os.remove(os.path.join(MONITOR_DIRECTORY, sep[4]))  # Remove after reading
+            except Exception as err:
+                print("Internal error: can't remove sub log file")
 
-    # Delete the file after reading
-    os.remove(os.path.join(MONITOR_DIRECTORY, 'sub_run_' + sub_id + '.txt'))
+    try:
+        # Delete the file after reading
+        os.remove(os.path.join(MONITOR_DIRECTORY, 'sub_run_' + sub_id + '.txt'))
+    except Exception as err:
+        print("Internal error: can't remove sub txt file")
     
     clang_tool_msg=""
 
-    
-    #Checking if any tool output exists or not 
-    if os.path.isfile(os.path.join(MONITOR_DIRECTORY,  'sub_clangjudge_'+sub_id+'.log')):
-        #If so copy output to variable
-        with open(os.path.join(MONITOR_DIRECTORY, 'sub_clangjudge_'+sub_id+'.log'),'r',encoding='utf-8') as f:
-            clang_tool_msg=str(f.read())
-        
-        #Remove file after copying output
-        os.remove(os.path.join(MONITOR_DIRECTORY,'sub_clangjudge_'+sub_id+'.log'))
+    try:
+        #Checking if any tool output exists or not 
+        if os.path.isfile(os.path.join(MONITOR_DIRECTORY,  'sub_clangjudge_'+sub_id+'.log')):
+            #If so copy output to variable
+            with open(os.path.join(MONITOR_DIRECTORY, 'sub_clangjudge_'+sub_id+'.log'),'r',encoding='utf-8') as f:
+                clang_tool_msg=str(f.read())
+            
+            #Remove file after copying output
+            os.remove(os.path.join(MONITOR_DIRECTORY,'sub_clangjudge_'+sub_id+'.log'))
 
-        #Priting to see if output is correct or not
-        #print(clang_tool_msg)
+            #Priting to see if output is correct or not
+            #print(clang_tool_msg)
 
-    #TODO:Handle displaying of errors when clang tool runs into a general compilation error [ should be displayed normally as error for submission ]
+        #TODO:Handle displaying of errors when clang tool runs into a general compilation error [ should be displayed normally as error for submission ]
+    except:
+        print("Internal error: Clang tool log error")
 
-    
-    problem = models.Problem.objects.get(pk=problem)
-    s = models.Submission.objects.get(pk=submission)
-    if clang_tool_msg:
-        s.clang_tool_msg = clang_tool_msg
+    try:
+        problem = models.Problem.objects.get(pk=problem)
+        s = models.Submission.objects.get(pk=submission)
+        if clang_tool_msg:
+            s.clang_tool_msg = clang_tool_msg
 
-    score_received = 0
-    max_score = problem.max_score 
+        score_received = 0
+        max_score = problem.max_score 
 
-    for i in range(len(testcase_id)):
-        
-        #If compilation fails then output error as normal error for test case
-        if verdict[i]=='CE':
-            clang_tool_msg="Tool Error:Compilation Failed.\nSee below for details why compilation failed"
-            s.clang_tool_msg=clang_tool_msg
+        for i in range(len(testcase_id)):
+            
+            #If compilation fails then output error as normal error for test case
+            if verdict[i]=='CE':
+                clang_tool_msg="Tool Error:Compilation Failed.\nSee below for details why compilation failed"
+                s.clang_tool_msg=clang_tool_msg
 
-        if clang_tool_msg and verdict[i]!='CE':
-            verdict[i] = 'F'
+            if clang_tool_msg and verdict[i]!='CE':
+                verdict[i] = 'F'
 
-        if verdict[i] == 'P':
-            score_received += max_score
-        st = models.SubmissionTestCase.objects.get(submission=submission,
-                                                testcase=testcase_id[i])
-        st.verdict = verdict[i]
-        st.memory_taken = int(memory[i])
-        st.time_taken = timedelta(seconds=float(time[i]))
-        if not clang_tool_msg or verdict[i]=='CE':
-            if verdict[i] == 'F' or verdict[i] == 'P':
-                with open(os.path.join(OUTPUT_DIRECTORY, 'outputfile_' + testcase_id[i] + '.txt'),'r') as f:
-                    st.msgfull = "Expected output:\n"+str(f.read())+"\nOutput:\n"+msg[i]
-                    if models.TestCase.objects.get(pk=testcase_id[i]).public:
-                        st.message = st.msgfull
-            else:
-                st.msgfull = msg[i] if len(msg[i]) < 1000 else msg[i][:1000] + '\\nMessage Truncated'
-                if not models.TestCase.objects.get(pk=testcase_id[i]).public and verdict[i] == 'RE':
-                    st.message = msg[i].splitlines()[-1]
+            if verdict[i] == 'P':
+                score_received += max_score
+            st = models.SubmissionTestCase.objects.get(submission=submission,
+                                                    testcase=testcase_id[i])
+            st.verdict = verdict[i]
+            st.memory_taken = int(memory[i])
+            st.time_taken = timedelta(seconds=float(time[i]))
+            if not clang_tool_msg or verdict[i]=='CE':
+                if verdict[i] == 'F' or verdict[i] == 'P':
+                    with open(os.path.join(OUTPUT_DIRECTORY, 'outputfile_' + testcase_id[i] + '.txt'),'r') as f:
+                        st.msgfull = "Expected output:\n"+str(f.read())+"\nOutput:\n"+msg[i]
+                        if models.TestCase.objects.get(pk=testcase_id[i]).public:
+                            st.message = st.msgfull
                 else:
-                    st.message = st.msgfull
-        
-        st.save()
-        
-    s.judge_score = score_received
+                    st.msgfull = msg[i] if len(msg[i]) < 1000 else msg[i][:1000] + '\\nMessage Truncated'
+                    if not models.TestCase.objects.get(pk=testcase_id[i]).public and verdict[i] == 'RE':
+                        st.message = msg[i].splitlines()[-1]
+                    else:
+                        st.message = st.msgfull
+            
+            st.save()
+            
+        s.judge_score = score_received
 
-    if s.problem.contest.enable_linter_score:
-        if s.file_type == '.py':
-            checker = Checker(
-                        os.path.join(CONTENT_DIRECTORY,
-                                     'submissions', 'submission_{}.py'.format(submission)),
-                        quiet=True)
-            checker.check_all()
-            s.linter_score = _compute_lint_score(checker.report)
-    current_final_score = s.judge_score + s.poster_score + s.linter_score
+        if s.problem.contest.enable_linter_score:
+            if s.file_type == '.py':
+                checker = Checker(
+                            os.path.join(CONTENT_DIRECTORY,
+                                        'submissions', 'submission_{}.py'.format(submission)),
+                            quiet=True)
+                checker.check_all()
+                s.linter_score = _compute_lint_score(checker.report)
+        current_final_score = s.judge_score + s.poster_score + s.linter_score
 
-    penalty_multiplier = 1.0
-    # If the submission crosses soft deadline
-    # Check if the submission has crossed the hard deadline
-    # If yes, penalty_multiplier = 0
-    # Else, penality_multiplier = 1 - num_of_days * penalty
-    remaining_time = problem.contest.soft_end_datetime - s.timestamp
-    if s.timestamp > problem.contest.soft_end_datetime:
-        if s.timestamp > problem.contest.hard_end_datetime:
-            penalty_multiplier = 0.0
-        else:
-            penalty_multiplier += remaining_time.days * problem.contest.penalty
+        penalty_multiplier = 1.0
+        # If the submission crosses soft deadline
+        # Check if the submission has crossed the hard deadline
+        # If yes, penalty_multiplier = 0
+        # Else, penality_multiplier = 1 - num_of_days * penalty
+        remaining_time = problem.contest.soft_end_datetime - s.timestamp
+        if s.timestamp > problem.contest.soft_end_datetime:
+            if s.timestamp > problem.contest.hard_end_datetime:
+                penalty_multiplier = 0.0
+            else:
+                penalty_multiplier += remaining_time.days * problem.contest.penalty
 
-    # If num_of_days * penalty > 1.0, then the score is clamped to zero
-    s.final_score = max(0.0, current_final_score * penalty_multiplier)
-    s.save()
+        # If num_of_days * penalty > 1.0, then the score is clamped to zero
+        s.final_score = max(0.0, current_final_score * penalty_multiplier)
+        s.save()
 
-    ppf, _ = models.PersonProblemFinalScore.objects.get_or_create(person=s.participant,
-                                                                  problem=problem)
-    if ppf.score <= s.final_score:
-        # <= because otherwise when someone submits for the first time and scores 0
-        # (s)he will not show up in leaderboard
-        ppf.score = s.final_score
-        update_lb = True
-    ppf.save()
+        ppf, _ = models.PersonProblemFinalScore.objects.get_or_create(person=s.participant,
+                                                                    problem=problem)
+        if ppf.score <= s.final_score:
+            # <= because otherwise when someone submits for the first time and scores 0
+            # (s)he will not show up in leaderboard
+            ppf.score = s.final_score
+            update_lb = True
+        ppf.save()
 
-    if update_lb:
-        # Update the leaderboard only if the submission improved the final score
-        handler.update_leaderboard(problem.contest.pk, s.participant.email)
+        if update_lb:
+            # Update the leaderboard only if the submission improved the final score
+            handler.update_leaderboard(problem.contest.pk, s.participant.email)
+    except Exception as err:
+        print("Internal Error: Database object create/update failed")
 
     return True
 
@@ -172,7 +193,7 @@ out = 1
 while out != 0:
     print("Building Docker image: {}....".format(DOCKER_IMAGE_NAME))
     # Build docker image using docker run
-    out = call(['docker', 'build', '-t', DOCKER_IMAGE_NAME, './'])
+    out = call(['sudo', 'docker', 'build', '-t', DOCKER_IMAGE_NAME, './'])
     if out != 0:
         print("Build failed, retrying...")
 
@@ -198,17 +219,23 @@ if not os.path.exists(MONITOR_DIRECTORY):
 
 
 while True:
-    if len(LS) < REFRESH_LS_TRIGGER:
-        # Neglect .log files in tmp/; these are for error
-        # messages arising at any stage of the evaluation
-        sleep(SLEEP_DUR_BEFORE_REFRESH)
-        LS = [os.path.join(MONITOR_DIRECTORY, sub_file)
-              for sub_file in os.listdir(MONITOR_DIRECTORY) if sub_file[:-4] != '.log']
-        LS.sort(key=os.path.getctime)
+    try:
+        if len(LS) < REFRESH_LS_TRIGGER:
+            # Neglect .log files in tmp/; these are for error
+            # messages arising at any stage of the evaluation
+            sleep(SLEEP_DUR_BEFORE_REFRESH)
+            LS = [os.path.join(MONITOR_DIRECTORY, sub_file)
+                for sub_file in os.listdir(MONITOR_DIRECTORY) if sub_file[:-4] != '.log']
+            LS.sort(key=os.path.getctime)
+    except Exception as err:
+        print("Internal Error: Refresh trigger failed")
 
     if len(LS) > 0:
-        sub_file = LS[0]  # The first file submission-wise
-        sub_id = os.path.basename(sub_file)[8:-4]  # This is the submission ID
+        try:
+            sub_file = LS[0]  # The first file submission-wise
+            sub_id = os.path.basename(sub_file)[8:-4]  # This is the submission ID
+        except Exception as err:
+            print("Internal Error: Couldn't get sub file name")
 
         # Move to content
         cur_dir = os.getcwd()
@@ -216,11 +243,17 @@ while True:
 
         # Run docker image
         print("INFO: evaluating submission: {}".format(sub_id))
-        call(['docker', 'run', '--rm', '-v', '{}:/app'.format(os.getcwd()),
-              '-e', 'SUB_ID={}'.format(sub_id), DOCKER_IMAGE_NAME])
+        try:
+            call(['sudo', 'docker', 'run', '--rm', '-v', '{}:/app'.format(os.getcwd()),
+                '-e', 'SUB_ID={}'.format(sub_id), DOCKER_IMAGE_NAME])
+        except Exception as err:
+            print("Internal Error: Docker evaluation failed")
 
         # Come back to parent directory
         os.chdir(cur_dir)
 
         saver(sub_id)
-        LS.remove(sub_file)
+        try:
+            LS.remove(sub_file)
+        except Exception as err:
+            print("Internal Error: Remove sub file from list failed")


### PR DESCRIPTION
This PR adds fixes for 
1. Timeout not working for certain submissions: Solved by cascading runsolver and timeout tool
2. Fix to increased file size: Runsolver and timeout tool runs in the background with a process polling the file size. 
    Kills the process if file size crosses a limit
3. Added file checks for executables while running the clang tool
4. Added extra ASCII checks for output files [ by @YashasAndaluri] 
5. Added fix for preventing the execution of a program if the clang tool fails [by @YashasAndaluri ]
6. Added stricter checks for implicit system calls to be caught by the clang tool
7. Change submission limit to be applied per problem and display it on problem detail page [by @YashasAndaluri ]
8. Added option to close submissions for a problem after contest start [by @YashasAndaluri ]
9. Made delete problem button available after submissions are closed [by @YashasAndaluri ]
10. Added option to disable evaluation for a contest [by @YashasAndaluri ]
11. Added separate download buttons for submissions that passed/failed clang checks [by @YashasAndaluri ]